### PR TITLE
Add ECDSA with SHA1 to sign signature

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -44,6 +44,7 @@ class JWT
         'RS256' => \OPENSSL_ALGO_SHA256,
         'RS384' => \OPENSSL_ALGO_SHA384,
         'RS512' => \OPENSSL_ALGO_SHA512,
+        'ECDSA' => 'ecdsa-with-SHA1',
     ];
 
     /** @var string|resource The signature key. */
@@ -70,12 +71,12 @@ class JWT
     /**
      * Constructor.
      *
-     * @param string|resource $key    The signature key. For RS* it should be file path or resource of private key.
-     * @param string          $algo   The algorithm to sign/verify the token.
-     * @param int             $maxAge The TTL of token to be used to determine expiry if `iat` claim is present.
-     *                                This is also used to provide default `exp` claim in case it is missing.
-     * @param int             $leeway Leeway for clock skew. Shouldnot be more than 2 minutes (120s).
-     * @param string          $pass   The passphrase (only for RS* algos).
+     * @param string|array|resource $key    The signature key. For RS* it should be file path or resource of private key.
+     * @param string                $algo   The algorithm to sign/verify the token.
+     * @param int                   $maxAge The TTL of token to be used to determine expiry if `iat` claim is present.
+     *                                      This is also used to provide default `exp` claim in case it is missing.
+     * @param int                   $leeway Leeway for clock skew. Shouldnot be more than 2 minutes (120s).
+     * @param string                $pass   The passphrase (only for RS* algos).
      */
     public function __construct($key, $algo = 'HS256', $maxAge = 3600, $leeway = 0, $pass = null)
     {

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -161,6 +161,12 @@ class JWTTest extends \PHPUnit\Framework\TestCase
             ['secret', 'HS512', rand(10, 1000), rand(1, 10), [
                 '_' . rand() => rand(),
             ]],
+            ['secret', 'ECDSA', rand(10, 1000), rand(1, 10), [
+                'uid'    => rand(),
+                'scopes' => ['user'],
+                'msg'    => 'fdsfdsf',
+                'iss'    => 'https://mysite.com',
+            ]],
         ];
     }
 
@@ -207,6 +213,9 @@ class JWTTest extends \PHPUnit\Framework\TestCase
                 'nbf' => time(),
             ]],
             ['NN=KK(*({:BJ', 'HS512',  10,  0,  -20,  JWT::ERROR_TOKEN_NOT_NOW, [
+                'nbf' => time() - 10,
+            ]],
+            ['NN=KK(*({:BJ', 'ECDSA',  10,  0,  -20,  JWT::ERROR_TOKEN_NOT_NOW, [
                 'nbf' => time() - 10,
             ]],
         ];


### PR DESCRIPTION
# Changed log
- Add `ECDSA` signature support and their related tests.
- The `$key` variable type is possible to be `string`, `resource` and `array`.
Add the missed `array` type on `JWT` class constructor annotation.
