### PR TITLE
refactor: php 8.4 - Deprecate implicitly nullable parameter types

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -84,7 +84,7 @@ class JWT
         string $algo = 'HS256',
         int $maxAge = 3600,
         int $leeway = 0,
-        string $pass = null
+        ?string $pass = null
     ) {
         $this->validateConfig($key, $algo, $maxAge, $leeway);
 
@@ -179,7 +179,7 @@ class JWT
      *
      * @param int|null $timestamp
      */
-    public function setTestTimestamp(int $timestamp = null): self
+    public function setTestTimestamp(?int $timestamp = null): self
     {
         $this->timestamp = $timestamp;
 


### PR DESCRIPTION
This resolves deprecation warnings in the Ahc\Jwt\JWT class and ensures compatibility with PHP 8.4.

Deprecation Messages:

Deprecated: Ahc\\Jwt\\JWT::__construct(): Implicitly marking parameter $pass as nullable is deprecated, the explicit nullable type must be used instead at ..../vendor/adhocore/jwt/src/JWT.php:82

Deprecated: Ahc\\Jwt\\JWT::setTestTimestamp(): Implicitly marking parameter $timestamp as nullable is deprecated, the explicit nullable type must be used instead at ..../vendor/adhocore/jwt/src/JWT.php:182
