### PR TITLE
Fix: JWT encode - custom 'typ'

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -116,6 +116,8 @@ class JWT
 
     /**
      * Encode payload as JWT token.
+     * 
+     * 'alg' in header is 
      *
      * @param array $payload
      * @param array $header  Extra header (if any) to append.
@@ -124,7 +126,10 @@ class JWT
      */
     public function encode(array $payload, array $header = []): string
     {
-        $header = ['typ' => 'JWT', 'alg' => $this->algo] + $header;
+        $header = $header + ['typ' => 'JWT'];
+
+        // `alg` is enforced; caller cannot override
+        $header['alg'] = $this->algo;
 
         $this->validateKid($header);
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -116,8 +116,6 @@ class JWT
 
     /**
      * Encode payload as JWT token.
-     * 
-     * 'alg' in header is 
      *
      * @param array $payload
      * @param array $header  Extra header (if any) to append.

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -222,4 +222,18 @@ class JWTTest extends \PHPUnit\Framework\TestCase
             ['decode', __FILE__, 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJuYmYiOjE0OTIwODkxODksImV4cCI6MTQ5MjA4OTE4OX0.fakesignature'],
         ];
     }
+    
+    public function test_custom_typ()
+    {
+        $jwt   = new JWT('KEY', 'HS256', 10, 0);
+        $token = $jwt->encode('PAYLOAD', [
+            'typ' => 'at+jwt'
+        ]);
+
+        $this->assertIsString($token);
+        $decoded = $jwt->decode($token);
+        $this->assertIsArray($decoded);
+
+        $this->assertSame('at+jwt', $decoded['typ']);
+    }
 }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -222,18 +222,21 @@ class JWTTest extends \PHPUnit\Framework\TestCase
             ['decode', __FILE__, 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJuYmYiOjE0OTIwODkxODksImV4cCI6MTQ5MjA4OTE4OX0.fakesignature'],
         ];
     }
-    
+
     public function test_custom_typ()
     {
         $jwt   = new JWT('KEY', 'HS256', 10, 0);
-        $token = $jwt->encode('PAYLOAD', [
+        $token = $jwt->encode(['uid' => 1], [
             'typ' => 'at+jwt'
         ]);
 
         $this->assertIsString($token);
-        $decoded = $jwt->decode($token);
-        $this->assertIsArray($decoded);
 
-        $this->assertSame('at+jwt', $decoded['typ']);
+        $segments = \explode('.', $token);
+        $headerSegment = $segments[0];
+        $headerJson = \base64_decode(\strtr($headerSegment, '-_', '+/'));
+        $header = \json_decode($headerJson, true);
+
+        $this->assertSame('at+jwt', $header['typ']);
     }
 }


### PR DESCRIPTION
When using this JWT library for OAuth2 (OIDC) server, specs require `typ` of JWT token to be `at+jwt`.

This PR allows override of the `typ`.

- [x] New tests to cover the use-case